### PR TITLE
Adding charts to project page

### DIFF
--- a/src/main/java/hudson/plugins/report/genericchart/ChartModel.java
+++ b/src/main/java/hudson/plugins/report/genericchart/ChartModel.java
@@ -24,41 +24,39 @@
 package hudson.plugins.report.genericchart;
 
 import hudson.Extension;
-import hudson.model.Job;
-import hudson.views.ListViewColumn;
-import hudson.views.ListViewColumnDescriptor;
-import java.util.List;
-import java.util.UUID;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-public class GenericChartColumn extends ListViewColumn {
+public class ChartModel extends AbstractDescribableImpl<ChartModel> {
 
+    private String title;
     private String fileNameGlob;
     private String key;
     private int limit;
-    private String columnCaption;
     private String chartColor;
 
     @DataBoundConstructor
-    public GenericChartColumn(String fileNameGlob, String key, int limit, String columnCaption, String chartColor) {
+    public ChartModel(String title, String fileNameGlob, String key, int limit, String chartColor) {
+        this.title = title;
         this.fileNameGlob = fileNameGlob;
         this.key = key;
         this.limit = limit;
-        this.columnCaption = columnCaption;
         this.chartColor = chartColor;
     }
 
-    public List<ChartPoint> getReportPoints(Job<?, ?> job) {
-        return new PropertiesParser().getReportPoints(job, new ChartModel(key, fileNameGlob, key, limit, chartColor));
+    public String getTitle() {
+        return title;
+    }
+
+    @DataBoundSetter
+    public void setTitle(String title) {
+        this.title = title;
     }
 
     public String getFileNameGlob() {
         return fileNameGlob;
-    }
-
-    public String generateChartName() {
-        return UUID.randomUUID().toString();
     }
 
     @DataBoundSetter
@@ -84,16 +82,6 @@ public class GenericChartColumn extends ListViewColumn {
         this.limit = limit;
     }
 
-    @Override
-    public String getColumnCaption() {
-        return columnCaption;
-    }
-
-    @DataBoundSetter
-    public void setColumnCaption(String columnCaption) {
-        this.columnCaption = columnCaption;
-    }
-
     public String getChartColor() {
         return chartColor;
     }
@@ -103,19 +91,19 @@ public class GenericChartColumn extends ListViewColumn {
         this.chartColor = chartColor;
     }
 
+    @Override
+    public Descriptor<ChartModel> getDescriptor() {
+        return DESCRIPTOR;
+    }
+
     @Extension
-    public static final GenericChartColumnDescriptor DESCRIPTOR = new GenericChartColumnDescriptor();
+    public static final ChartDescriptor DESCRIPTOR = new ChartDescriptor();
 
-    public static class GenericChartColumnDescriptor extends ListViewColumnDescriptor {
-
-        @Override
-        public boolean shownByDefault() {
-            return false;
-        }
+    public static class ChartDescriptor extends Descriptor<ChartModel> {
 
         @Override
         public String getDisplayName() {
-            return "Chart";
+            return "Chart from properties";
         }
 
     }

--- a/src/main/java/hudson/plugins/report/genericchart/ChartPoint.java
+++ b/src/main/java/hudson/plugins/report/genericchart/ChartPoint.java
@@ -23,18 +23,24 @@
  */
 package hudson.plugins.report.genericchart;
 
-public class ReportPoint {
+public class ChartPoint {
 
     private final String buildName;
+    private final int buildNumber;
     private final int value;
 
-    public ReportPoint(String buildName, int value) {
+    public ChartPoint(String buildName, int buildNumber, int value) {
         this.buildName = buildName;
+        this.buildNumber = buildNumber;
         this.value = value;
     }
 
     public String getBuildName() {
         return buildName;
+    }
+
+    public int getBuildNumber() {
+        return buildNumber;
     }
 
     public int getValue() {

--- a/src/main/java/hudson/plugins/report/genericchart/GenericChartColumn.java
+++ b/src/main/java/hudson/plugins/report/genericchart/GenericChartColumn.java
@@ -163,6 +163,7 @@ public class GenericChartColumn extends ListViewColumn {
         return chartColor;
     }
 
+    @DataBoundSetter
     public void setChartColor(String chartColor) {
         this.chartColor = chartColor;
     }

--- a/src/main/java/hudson/plugins/report/genericchart/GenericChartProjectAction.java
+++ b/src/main/java/hudson/plugins/report/genericchart/GenericChartProjectAction.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 user.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.report.genericchart;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GenericChartProjectAction implements Action {
+
+    private final Job<?, ?> job;
+    private final List<ChartModel> charts;
+
+    public GenericChartProjectAction(Job<?, ?> job, List<ChartModel> charts) {
+        this.job = job;
+        this.charts = charts;
+    }
+
+    public List<ReportChart> getCharts() {
+        if (charts == null || charts.isEmpty()) {
+            return new ArrayList<>();
+        }
+        PropertiesParser parser = new PropertiesParser();
+        List<ReportChart> list = charts.stream()
+                .sequential()
+                .map(m -> new ReportChart(m.getTitle(), m.getChartColor(), parser.getReportPoints(job, m)))
+                .filter(r -> r.getPoints() != null && r.getPoints().size() > 0)
+                .collect(Collectors.toList());
+        return list;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+}

--- a/src/main/java/hudson/plugins/report/genericchart/GenericChartPublisher.java
+++ b/src/main/java/hudson/plugins/report/genericchart/GenericChartPublisher.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 user.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.report.genericchart;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class GenericChartPublisher extends Publisher {
+
+    private List<ChartModel> charts;
+
+    @DataBoundConstructor
+    public GenericChartPublisher(List<ChartModel> charts) {
+        this.charts = charts;
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        return true;
+    }
+
+    @Override
+    public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
+        if (/* getAction(Class) produces a StackOverflowError */!Util.filter(
+                        project.getActions(), GenericChartProjectAction.class).isEmpty()) {
+            // JENKINS-26077: someone like XUnitPublisher already added one
+            return Collections.emptySet();
+        }
+        return Collections.singleton(new GenericChartProjectAction(project, charts));
+    }
+
+    public List<ChartModel> getCharts() {
+        return charts;
+    }
+
+    @DataBoundSetter
+    public void setCharts(List<ChartModel> charts) {
+        this.charts = charts;
+    }
+
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+    public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        public List<ChartModel.ChartDescriptor> getItemDescriptors() {
+            return Jenkins.getInstance().getDescriptorList(ChartModel.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Charts from properties";
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+    }
+
+}

--- a/src/main/java/hudson/plugins/report/genericchart/PropertiesParser.java
+++ b/src/main/java/hudson/plugins/report/genericchart/PropertiesParser.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 user.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.report.genericchart;
+
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class PropertiesParser {
+
+    public List<ChartPoint> getReportPoints(Job<?, ?> job, ChartModel chart) {
+        List<ChartPoint> list = new ArrayList<>();
+
+        Predicate<String> lineValidator = str -> {
+            if (str == null || str.trim().isEmpty()) {
+                return false;
+            }
+            int index = str.indexOf('=');
+            if (index <= 0) {
+                return false;
+            }
+            if (!str.substring(0, index).trim().equals(chart.getKey().trim())) {
+                return false;
+            }
+            try {
+                Integer.parseInt(str.substring(index + 1).trim());
+                return true;
+            } catch (Exception ignore) {
+            }
+            return false;
+        };
+
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + chart.getFileNameGlob());
+        for (Run run : job.getBuilds()) {
+            if (run.getResult() == null || run.getResult().isWorseThan(Result.UNSTABLE)) {
+                continue;
+            }
+            try {
+                Optional<ChartPoint> optPoint = Files.walk(run.getRootDir().toPath())
+                        .filter(p -> matcher.matches(p.getFileName()))
+                        .map(p -> lines(p)
+                                .filter(lineValidator)
+                                .findFirst().get())
+                        .map(s -> new ChartPoint(
+                                run.getDisplayName(),
+                                run.getNumber(),
+                                Integer.parseInt(s.substring(s.indexOf('=') + 1).trim())))
+                        .findFirst();
+                if (optPoint.isPresent()) {
+                    list.add(optPoint.get());
+                }
+            } catch (Exception ignore) {
+            }
+            if (list.size() == chart.getLimit()) {
+                break;
+            }
+        }
+
+        Collections.reverse(list);
+        return list;
+    }
+
+    private Stream<String> lines(Path path) {
+        try {
+            return Files.lines(path);
+        } catch (Exception ignore) {
+        }
+        return Stream.empty();
+    }
+
+}

--- a/src/main/java/hudson/plugins/report/genericchart/ReportChart.java
+++ b/src/main/java/hudson/plugins/report/genericchart/ReportChart.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 user.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.report.genericchart;
+
+import java.util.List;
+
+public class ReportChart {
+
+    private final String title;
+    private final String color;
+    private final List<ChartPoint> points;
+
+    public ReportChart(String title, String color, List<ChartPoint> points) {
+        this.title = title;
+        this.color = color;
+        this.points = points;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public List<ChartPoint> getPoints() {
+        return points;
+    }
+
+}

--- a/src/main/resources/hudson/plugins/report/genericchart/ChartModel/config.jelly
+++ b/src/main/resources/hudson/plugins/report/genericchart/ChartModel/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry field="columnCaption" title="Chart name">
+    <f:entry field="title" title="Chart name">
         <f:textbox />
     </f:entry>
     <f:entry field="fileNameGlob" title="Glob pattern for the report file to parse">

--- a/src/main/resources/hudson/plugins/report/genericchart/GenericChartColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/report/genericchart/GenericChartColumn/column.jelly
@@ -16,7 +16,7 @@
                     var data = {
                     labels: [
                     <j:forEach var="build" items="${points}" varStatus="status">
-                    "${build.buildName}"<j:if test="${!status.last}">,</j:if>
+                    "${build.buildNumber}"<j:if test="${!status.last}">,</j:if>
                     </j:forEach>
                     ],
                             datasets: [{

--- a/src/main/resources/hudson/plugins/report/genericchart/GenericChartColumn/config.jelly
+++ b/src/main/resources/hudson/plugins/report/genericchart/GenericChartColumn/config.jelly
@@ -1,5 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry field="columnCaption" title="Caption of the column">
+        <f:textbox />
+    </f:entry>
     <f:entry field="fileNameGlob" title="Glob pattern for the report file to parse">
         <f:textbox />
     </f:entry>

--- a/src/main/resources/hudson/plugins/report/genericchart/GenericChartProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/report/genericchart/GenericChartProjectAction/floatingBox.jelly
@@ -1,0 +1,54 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
+    <j:set var="charts" value="${action.charts}" />
+    <j:if test="${!charts.isEmpty()}">
+        <j:forEach var="chart" items="${charts}" varStatus="chartsStatus">
+            <h3 style="font-family: monospace">${chart.title}</h3>
+            <div id="chartContainer${chartsStatus.index}" style="margin-right: 10pt">
+                <canvas id='chart${chartsStatus.index}' width='600' height='300'>
+                </canvas>
+            </div>
+            <script type="text/javascript">
+                // &lt;![CDATA[
+                var data = {
+                labels: [
+                <j:forEach var="build" items="${chart.points}" varStatus="status">
+                "${build.buildName}"<j:if test="${!status.last}">,</j:if>
+                </j:forEach>
+                ],
+                        datasets: [
+                        {
+                        label: "${chart.title}",
+                                fillColor: "${chart.color}",
+                                strokeColor: "${chart.color}",
+                                pointColor: "${chart.color}",
+                                pointStrokeColor: "#fff",
+                                pointHighlightFill: "#fff",
+                                pointHighlightStroke: "rgba(180,180,180,1)",
+                                data: [
+                <j:forEach var="build" items="${chart.points}" varStatus="status">
+                    ${build.value}<j:if test="${!status.last}">,</j:if>
+                </j:forEach>
+                                ]
+                        }
+                        ]
+                };
+                var options = {
+                bezierCurve: false,
+                        multiTooltipTemplate: "&lt;%= datasetLabel + \": \" + value %&gt;"
+                };
+                var ctx = document.getElementById("chart${chartsStatus.index}").getContext("2d");
+                var jckPassedChart = new Chart(ctx).Line(data, options);
+                var buildsMap = {};
+                <j:forEach var="build" items="${jckReports.reports}" varStatus="status">
+                buildsMap["${build.buildName}"] = "${build.buildNumber}";
+                </j:forEach>
+                document.getElementById("chartContainer${chartsStatus.index}").onclick = function (evt) {
+                var activePoints = jckPassedChart.getPointsAtEvent(evt);
+                window.open(buildsMap[activePoints[0].label], "_blank");
+                };
+                // ]]&gt;
+            </script>
+        </j:forEach>
+    </j:if>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/report/genericchart/GenericChartPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/report/genericchart/GenericChartPublisher/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Charts" field="charts">
+        <f:hetero-list name="charts" 
+                       hasHeader="true"
+                       descriptors="${descriptor.itemDescriptors}"
+                       items="${instance.charts}"
+                       addCaption="Add Chart"
+                       deleteCaption="Delete Chart"/>
+    </f:entry>
+</j:jelly>


### PR DESCRIPTION
Having chart only on the front page appeared to be not informative enough and not really usable. Had to add similar chart to the project page, to better list builds and navigate if needed.