### PR TITLE
Adding support for Double in charts.

### DIFF
--- a/src/main/java/hudson/plugins/report/genericchart/ChartPoint.java
+++ b/src/main/java/hudson/plugins/report/genericchart/ChartPoint.java
@@ -27,9 +27,9 @@ public class ChartPoint {
 
     private final String buildName;
     private final int buildNumber;
-    private final int value;
+    private final String value;
 
-    public ChartPoint(String buildName, int buildNumber, int value) {
+    public ChartPoint(String buildName, int buildNumber, String value) {
         this.buildName = buildName;
         this.buildNumber = buildNumber;
         this.value = value;
@@ -43,7 +43,7 @@ public class ChartPoint {
         return buildNumber;
     }
 
-    public int getValue() {
+    public String getValue() {
         return value;
     }
 

--- a/src/main/java/hudson/plugins/report/genericchart/PropertiesParser.java
+++ b/src/main/java/hudson/plugins/report/genericchart/PropertiesParser.java
@@ -54,7 +54,7 @@ public class PropertiesParser {
                 return false;
             }
             try {
-                Integer.parseInt(str.substring(index + 1).trim());
+                Double.parseDouble(str.substring(index + 1).trim());
                 return true;
             } catch (Exception ignore) {
             }
@@ -75,7 +75,7 @@ public class PropertiesParser {
                         .map(s -> new ChartPoint(
                                 run.getDisplayName(),
                                 run.getNumber(),
-                                Integer.parseInt(s.substring(s.indexOf('=') + 1).trim())))
+                                s.substring(s.indexOf('=') + 1).trim()))
                         .findFirst();
                 if (optPoint.isPresent()) {
                     list.add(optPoint.get());

--- a/src/main/resources/hudson/plugins/report/genericchart/GenericChartProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/report/genericchart/GenericChartProjectAction/floatingBox.jelly
@@ -40,7 +40,7 @@
                 var ctx = document.getElementById("chart${chartsStatus.index}").getContext("2d");
                 var jckPassedChart = new Chart(ctx).Line(data, options);
                 var buildsMap = {};
-                <j:forEach var="build" items="${jckReports.reports}" varStatus="status">
+                <j:forEach var="build" items="${chart.points}" varStatus="status">
                 buildsMap["${build.buildName}"] = "${build.buildNumber}";
                 </j:forEach>
                 document.getElementById("chartContainer${chartsStatus.index}").onclick = function (evt) {


### PR DESCRIPTION
Validator is using `Double.parseDouble()` instead of `Integer.parseInt()` now. Java side keeps the value as string, letting weakly-typed JavaScript to handle the transformation and parsing.