### PR TITLE
add comment about bug in rangeAroundWhiteList feature. Bug: Point(a) …

### DIFF
--- a/src/main/java/hudson/plugins/report/genericchart/PropertiesParser.java
+++ b/src/main/java/hudson/plugins/report/genericchart/PropertiesParser.java
@@ -114,7 +114,11 @@ public class PropertiesParser {
                                 /*Preventing duplicates in whitelist. Not because of the graph, there is
                                 already chunk of code preventing from showing duplicity in the graph.
                                 (The final list are recreated again with help of these lists)
-                                Its because lenght of whitelist which is shown over the graph.*/
+                                Its because lenght of whitelist which is shown over the graph.
+                                BUG
+                                We have some point(a) which is in range around whitelist and point(b) which
+                                have same name but its not in range. Bug is that both points are shown in result
+                                its caused by generating second array(graph points) from names contained in this array*/
                                 if (!result.contains(builds[i + j].getDisplayName())) {
                                     result.add(builds[i + j].getDisplayName());
                                 }


### PR DESCRIPTION
…and point(b) have same name if one is in the range the second is added to graph no matter where is actualy is