### PR TITLE
Points around whitelisted ones have different color

### DIFF
--- a/src/main/java/hudson/plugins/report/genericchart/ChartModel.java
+++ b/src/main/java/hudson/plugins/report/genericchart/ChartModel.java
@@ -47,7 +47,11 @@ public class ChartModel extends AbstractDescribableImpl<ChartModel> {
         this.fileNameGlob = fileNameGlob;
         this.key = key;
         this.limit = limit;
-        this.chartColor = chartColor;
+        if (chartColor == null || chartColor.isEmpty()) {
+            this.chartColor = ColorChanger.randomColor();
+        } else {
+            this.chartColor = chartColor;
+        }
         this.rangeAroundWlist = rangeAroundWlist;
     }
 

--- a/src/main/java/hudson/plugins/report/genericchart/ChartModel.java
+++ b/src/main/java/hudson/plugins/report/genericchart/ChartModel.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.report.genericchart;
 
+import hudson.plugins.ColorChanger;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -139,4 +140,11 @@ public class ChartModel extends AbstractDescribableImpl<ChartModel> {
         return resultsWhiteList;
     }
 
+    public String getPointColor(boolean isInRangeOfWhiteListed) {
+        if (isInRangeOfWhiteListed) {
+            //there is 32 because it slightly change shade of color so graph is more readable
+            return ColorChanger.shiftColorBy(chartColor, 64, 64, 32);
+        }
+        return chartColor;
+    }
 }

--- a/src/main/java/hudson/plugins/report/genericchart/ChartPoint.java
+++ b/src/main/java/hudson/plugins/report/genericchart/ChartPoint.java
@@ -31,12 +31,14 @@ public class ChartPoint {
     private final String buildNameShortened;
     private final int buildNumber;
     private final String value;
+    private final String pointColor;
 
-    public ChartPoint(String buildName, int buildNumber, String value) {
+    public ChartPoint(String buildName, int buildNumber, String value, String pointColor) {
         this.buildName = buildName;
-        this.buildNameShortened=Chartjs.getShortName(buildName, buildNumber);
+        this.buildNameShortened = Chartjs.getShortName(buildName, buildNumber);
         this.buildNumber = buildNumber;
         this.value = value;
+        this.pointColor = pointColor;
     }
 
     public String getBuildName() {
@@ -53,6 +55,10 @@ public class ChartPoint {
 
     public String getValue() {
         return value;
+    }
+
+    public String getPointColor() {
+        return pointColor;
     }
 
 }

--- a/src/main/java/hudson/plugins/report/genericchart/PropertiesParser.java
+++ b/src/main/java/hudson/plugins/report/genericchart/PropertiesParser.java
@@ -81,7 +81,7 @@ public class PropertiesParser {
     /*
     Counting white list size without surroundings which is needed in title over the graph
      */
-    int getWhiteListSizeWithoutSurroundings(Job<?, ?> job, ChartModel chart) {
+    List<String> getWhiteListWithoutSurroundings(Job<?, ?> job, ChartModel chart) {
         return getList(job, chart, new ListProvider() {
             @Override
             public String getList() {
@@ -92,7 +92,7 @@ public class PropertiesParser {
             public int getSurrounding() {
                 return 0;
             }
-        }).toArray().length;
+        });
 
     }
 
@@ -170,7 +170,10 @@ public class PropertiesParser {
         PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + chart.getFileNameGlob());
         List<String> blacklisted = getBlacklisted(job, chart);
         List<String> whitelisted = getWhitelisted(job, chart);
-        int whiteListSizeWithoutSurroundings = getWhiteListSizeWithoutSurroundings(job, chart);
+        List<String> whiteListWithoutSurroundings = getWhiteListWithoutSurroundings(job, chart);
+        List<String> pointsInRangeOfwhitelisted = new ArrayList<>(whitelisted);
+        int whiteListSizeWithoutSurroundings = whiteListWithoutSurroundings.toArray().length;
+        pointsInRangeOfwhitelisted.removeAll(whiteListWithoutSurroundings);
         for (Run run : job.getBuilds()) {
             if (run.getResult() == null || run.getResult().isWorseThan(Result.UNSTABLE)) {
                 continue;
@@ -191,7 +194,8 @@ public class PropertiesParser {
                         .map(s -> new ChartPoint(
                                 run.getDisplayName(),
                                 run.getNumber(),
-                                extractValue(s)))
+                                extractValue(s),
+                                chart.getPointColor(pointsInRangeOfwhitelisted.contains(run.getDisplayName()))))
                         .findFirst();
                 if (optPoint.isPresent()) {
                     list.add(optPoint.get());

--- a/src/main/resources/hudson/plugins/report/genericchart/GenericChartColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/report/genericchart/GenericChartColumn/column.jelly
@@ -31,7 +31,14 @@
                     <j:forEach var="build" items="${points}" varStatus="status">
                         ${build.value}<j:if test="${!status.last}">,</j:if>
                     </j:forEach>
-                                    ]}]
+                                ],
+                                coloredTips: [
+                    <j:forEach var="build" items="${points}" varStatus="status">
+                        "${build.pointColor}"<j:if test="${!status.last}">,</j:if>
+                    </j:forEach>
+                                ]
+                        }
+                        ]
                     };
                     var options = {
                         bezierCurve: false,

--- a/src/main/resources/hudson/plugins/report/genericchart/GenericChartProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/report/genericchart/GenericChartProjectAction/floatingBox.jelly
@@ -22,13 +22,17 @@
                         label: "${chart.title}",
                                 fillColor: "${chart.color}",
                                 strokeColor: "${chart.color}",
-                                pointColor: "${chart.color}",
-                                pointStrokeColor: "#fff",
+                                pointStrokeColor: "#808080",
                                 pointHighlightFill: "#fff",
-                                pointHighlightStroke: "rgba(180,180,180,1)",
+                                pointHighlightStroke: "rgba(0,0,0,1)",
                                 data: [
                 <j:forEach var="build" items="${chart.points}" varStatus="status">
                     ${build.value}<j:if test="${!status.last}">,</j:if>
+                </j:forEach>
+                                ],
+                                coloredTips: [
+                <j:forEach var="build" items="${chart.points}" varStatus="status">
+                    "${build.pointColor}"<j:if test="${!status.last}">,</j:if>
                 </j:forEach>
                                 ]
                         }


### PR DESCRIPTION
New color is calculated from color of the graph
In PropertiesParser:
	Is new ArrayList (pointsInRangeOfWhitelisted) which contains all point which are in range of whitelisted
	rename getWhiteListSizeWithoutSurroundings because it now returns whole list (change is because the list is used to calculate list I mentioned above)
In floatingbox.jelly:
	change in default settings of colors
		pointStrokeColor: 	white->gray because its more visible
		pointHighlighStroke:	gray ->black to keep contrast between highlighted and normalStroke
	Generating new property ColoredTips which is list of colors. For any point is color in this list.